### PR TITLE
chore: allow node 14

### DIFF
--- a/howmanypeoplearethereinthe.world/package.json
+++ b/howmanypeoplearethereinthe.world/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "12.x"
+    "node": "12.x || 14.x"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Node 14 is now LTS